### PR TITLE
Update rspamd.spec in order to accomodate 1.7.4

### DIFF
--- a/rspamd.spec
+++ b/rspamd.spec
@@ -1,5 +1,5 @@
 Name:             rspamd
-Version:          1.7.1
+Version:          1.7.4
 Release:          1%{?dist}
 Summary:          Rapid spam filtering system
 License:          ASL 2.0 and LGPLv2+ and LGPLv3 and BSD and MIT and CC0 and zlib
@@ -9,14 +9,16 @@ Source1:          80-rspamd.preset
 Source2:          rspamd.service
 Source3:          rspamd.logrotate
 #Source4:          rspamd-sysusers.conf
-Patch0:           rspamd-secure-ssl-ciphers.patch
+
 
 BuildRequires:    cmake
 BuildRequires:    fann-devel
 BuildRequires:    file-devel
 BuildRequires:    glib2-devel
 BuildRequires:    gmime-devel
+%ifarch x86_64
 BuildRequires:    hyperscan-devel
+%endif
 BuildRequires:    libaio-devel
 BuildRequires:    libevent-devel
 BuildRequires:    libicu-devel
@@ -89,7 +91,6 @@ lua.
 
 %prep
 %setup -q
-%patch0 -p1
 rm -rf centos
 rm -rf debian
 rm -rf docker
@@ -189,6 +190,10 @@ install -Dpm 0644 %{SOURCE3} %{buildroot}%{_sysconfdir}/logrotate.d/rspamd
 %{_unitdir}/rspamd.service
 
 %changelog
+* Fri May 18 2018 patrick@pichon.me - 1.7.4
+- Updated for 1.7.4 release
+- Make hyperscan-devel only for x86_64 architecure for which the package exist
+
 * Sun Mar 25 2018 evan@eklitzke.org - 1.7.1-1
 - Updated for 1.7.1 release
 

--- a/rspamd.spec
+++ b/rspamd.spec
@@ -9,7 +9,7 @@ Source1:          80-rspamd.preset
 Source2:          rspamd.service
 Source3:          rspamd.logrotate
 #Source4:          rspamd-sysusers.conf
-
+Patch0: rspamd-secure-ssl-ciphers.patch
 
 BuildRequires:    cmake
 BuildRequires:    fann-devel
@@ -91,6 +91,7 @@ lua.
 
 %prep
 %setup -q
+%patch0 -p1
 rm -rf centos
 rm -rf debian
 rm -rf docker


### PR DESCRIPTION
This is to handle the recent 1.7.4 release
I have also put a condition on hyperscan-devel as this is only available on x86_64 architecture