### PR TITLE
Run 'make' using cpu parallelism

### DIFF
--- a/rspamd.spec
+++ b/rspamd.spec
@@ -130,6 +130,7 @@ rm -rf freebsd
   -DNO_SHARED=ON \
   -DRSPAMD_USER=%{name} \
   -DRSPAMD_GROUP=%{name}
+%make_build
 
 %pre
 %sysusers_create_package %{name} %{SOURCE4}


### PR DESCRIPTION
Right now the actual `make` step that compiles the code is really being triggered by the `%{make_install}` macro in the `%install` section. This sort of works, but it has the unintended side-effect that make doesn't use any CPU parallelism. By using `%make_build` in the `%build` section, RPM packaging will automatically use the same number of parallel make jobs as the host has CPU parallelism.