### PR TITLE
Rspamd version 2.2 released

### DIFF
--- a/rspamd.spec
+++ b/rspamd.spec
@@ -50,6 +50,8 @@ Requires:         logrotate
 Provides: bundled(aho-corasick)
 # cdb: Public Domain
 Provides: bundled(cdb) = 1.1.0
+# fastutf8: MIT
+Provides: bundled(fastutf8)
 # hiredis: BSD-3-Clause
 Provides: bundled(hiredis) = 0.13.3
 # kann: MIT
@@ -206,6 +208,7 @@ install -Dpm 0644 LICENSE.md %{buildroot}%{_docdir}/licenses/LICENSE.md
 %changelog
 * Tue Nov 26 2019 Johan Kok <johan@fedoraproject.org> - 2.2-1
 - Update to 2.2
+- Added bundled Provides for fastutf8
 
 * Sat Nov 09 2019 Johan Kok <johan@fedoraproject.org> - 2.1-1
 - Update to 2.1

--- a/rspamd.spec
+++ b/rspamd.spec
@@ -1,5 +1,5 @@
 Name:             rspamd
-Version:          2.1
+Version:          2.2
 Release:          1%{?dist}
 Summary:          Rapid spam filtering system
 License:          ASL 2.0 and LGPLv3 and BSD and MIT and CC0 and zlib
@@ -204,6 +204,9 @@ install -Dpm 0644 LICENSE.md %{buildroot}%{_docdir}/licenses/LICENSE.md
 %{_sysusersdir}/%{name}.conf
 
 %changelog
+* Tue Nov 26 2019 Johan Kok <johan@fedoraproject.org> - 2.2-1
+- Update to 2.2
+
 * Sat Nov 09 2019 Johan Kok <johan@fedoraproject.org> - 2.1-1
 - Update to 2.1
 - Added BuildRequire for libsodium


### PR DESCRIPTION
...and there is [version 2.2](https://rspamd.com/announce/2019/11/19/rspamd-2.2.html). Here's a updated .spec file for the new source with a new bundled library.