### PR TITLE
Fix for linking with gcc12

### DIFF
--- a/rspamd-3.4-Deserialise_hyperscan_to_the_page-aligned_space_to_prevent_alignment_issues.patch
+++ b/rspamd-3.4-Deserialise_hyperscan_to_the_page-aligned_space_to_prevent_alignment_issues.patch
@@ -1,0 +1,32 @@
+From 068714f9f5a96fbd94560211cec75775ee023d02 Mon Sep 17 00:00:00 2001
+From: Vsevolod Stakhov <vsevolod@rspamd.com>
+Date: Fri, 11 Nov 2022 20:34:51 +0000
+Subject: [PATCH] [CritFix] Deserialise hyperscan to the page-aligned space to
+ prevent alignment issues
+
+Issue: #4329
+---
+ src/libserver/hyperscan_tools.cxx | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/libserver/hyperscan_tools.cxx b/src/libserver/hyperscan_tools.cxx
+index 6187208a9..96366067d 100644
+--- a/src/libserver/hyperscan_tools.cxx
++++ b/src/libserver/hyperscan_tools.cxx
+@@ -306,7 +306,15 @@ auto load_cached_hs_file(const char *fname, std::int64_t offset = 0) -> tl::expe
+ 						msg_debug_hyperscan_lambda("multipattern: create new database in %s; %Hz size",
+ 							tmpfile_pattern.data(), unserialized_size);
+ 						void *buf;
+-						posix_memalign(&buf, 16, unserialized_size);
++#ifdef HAVE_GETPAGESIZE
++						auto page_size = getpagesize();
++#else
++						auto page_size = sysconf(_SC_PAGESIZE);
++#endif
++						if (page_size == -1) {
++							page_size = 4096;
++						}
++						posix_memalign(&buf, page_size, unserialized_size);
+ 						if (buf == nullptr) {
+ 							return tl::make_unexpected(error {"Cannot allocate memory", errno, error_category::CRITICAL });
+ 						}

--- a/rspamd.spec
+++ b/rspamd.spec
@@ -1,6 +1,6 @@
 Name:             rspamd
 Version:          3.4
-Release:          1%{?dist}
+Release:          2%{?dist}
 Summary:          Rapid spam filtering system
 License:          ASL 2.0 and LGPLv3 and BSD and MIT and CC0 and zlib
 URL:              https://www.rspamd.com/
@@ -12,6 +12,9 @@ Source4:          rspamd.sysusers
 Source5:          rspamd.tmpfilesd
 Patch0:           rspamd-secure-ssl-ciphers.patch
 Patch1:           rspamd-3.4-Deserialise_hyperscan_to_the_page-aligned_space_to_prevent_alignment_issues.patch
+
+# see https://bugzilla.redhat.com/show_bug.cgi?id=2043092
+%undefine _package_note_flags
 
 BuildRequires:    cmake
 BuildRequires:    gcc
@@ -149,9 +152,6 @@ rm -rf freebsd
   -DENABLE_LUAJIT=OFF \
 %endif
   -DENABLE_PCRE2=ON \
-%if 0%{?fedora} >= 36
-  -DLINKER_NAME=/usr/bin/ld.bfd \
-%endif
   -DRSPAMD_USER=%{name}
 %cmake_build
 
@@ -216,6 +216,9 @@ install -Dpm 0644 LICENSE.md %{buildroot}%{_docdir}/licenses/LICENSE.md
 %dir %attr(0750,%{name},%{name}) %{_localstatedir}/log/%{name}
 
 %changelog
+* Fri Nov 25 2022 Ajay Ramaswamy <ajay@ramaswamy.net> - 3.4-2
+- fix gcc 12 linker see rhbz #2043092
+
 * Thu Nov 17 2022 Ajay Ramaswamy <ajay@ramaswamy.net> - 3.4-1
 - update to 3.4
 - fix crash in hyperscan see https://github.com/rspamd/rspamd/issues/4329

--- a/rspamd.spec
+++ b/rspamd.spec
@@ -1,6 +1,6 @@
 Name:             rspamd
-Version:          3.1
-Release:          3%{?dist}
+Version:          3.3
+Release:          1%{?dist}
 Summary:          Rapid spam filtering system
 License:          ASL 2.0 and LGPLv3 and BSD and MIT and CC0 and zlib
 URL:              https://www.rspamd.com/
@@ -148,6 +148,9 @@ rm -rf freebsd
   -DENABLE_LUAJIT=OFF \
 %endif
   -DENABLE_PCRE2=ON \
+%if 0%{?fedora} >= 36
+  -DLINKER_NAME=/usr/bin/ld.bfd \
+%endif
   -DRSPAMD_USER=%{name}
 %cmake_build
 
@@ -212,6 +215,10 @@ install -Dpm 0644 LICENSE.md %{buildroot}%{_docdir}/licenses/LICENSE.md
 %dir %attr(0750,%{name},%{name}) %{_localstatedir}/log/%{name}
 
 %changelog
+* Mon Nov 07 2022 Ajay Ramaswamy <ajay@ramaswamy.net> - 3.3-1
+- update to 3.3
+- use ld.bfd to link on Fedora 36+
+
 * Wed Mar 09 2022 Christian Glombek <lorbus@fedoraproject.org> - 3.1-3
 - Add missing runtime dependencies
 - Add log and run dirs

--- a/rspamd.spec
+++ b/rspamd.spec
@@ -1,5 +1,5 @@
 Name:             rspamd
-Version:          3.3
+Version:          3.4
 Release:          1%{?dist}
 Summary:          Rapid spam filtering system
 License:          ASL 2.0 and LGPLv3 and BSD and MIT and CC0 and zlib
@@ -11,6 +11,7 @@ Source3:          rspamd.logrotate
 Source4:          rspamd.sysusers
 Source5:          rspamd.tmpfilesd
 Patch0:           rspamd-secure-ssl-ciphers.patch
+Patch1:           rspamd-3.4-Deserialise_hyperscan_to_the_page-aligned_space_to_prevent_alignment_issues.patch
 
 BuildRequires:    cmake
 BuildRequires:    gcc
@@ -215,6 +216,10 @@ install -Dpm 0644 LICENSE.md %{buildroot}%{_docdir}/licenses/LICENSE.md
 %dir %attr(0750,%{name},%{name}) %{_localstatedir}/log/%{name}
 
 %changelog
+* Thu Nov 17 2022 Ajay Ramaswamy <ajay@ramaswamy.net> - 3.4-1
+- update to 3.4
+- fix crash in hyperscan see https://github.com/rspamd/rspamd/issues/4329
+
 * Mon Nov 07 2022 Ajay Ramaswamy <ajay@ramaswamy.net> - 3.3-1
 - update to 3.3
 - use ld.bfd to link on Fedora 36+


### PR DESCRIPTION
Since the previous approach did not work on Centos / RHEL and also aarch64 this was the other fix that popped up on fedora-devel mailing list you can pull this and try a build in koji. I have tested with mockbuild locally and it works OK with my mailserver, but this is all x86_64 and FC37. I cannot test other configs easily.